### PR TITLE
Return error level != 0 for parsing errors.

### DIFF
--- a/InteractiveHtmlBom/core/ibom.py
+++ b/InteractiveHtmlBom/core/ibom.py
@@ -295,14 +295,14 @@ def main(parser, config, logger):
 
     if extra_fields is None and need_extra_fields:
         logger.error('Failed parsing %s' % config.netlist_file)
-        return
+        return False
 
     extra_fields = extra_fields[1] if extra_fields else None
 
     pcbdata, components = parser.parse()
     if not pcbdata or not components:
         logger.error('Parsing failed.')
-        return
+        return False
 
     pcbdata["bom"] = generate_bom(components, config, extra_fields)
     pcbdata["ibom_version"] = config.version
@@ -313,6 +313,8 @@ def main(parser, config, logger):
     if config.open_browser:
         logger.info("Opening file in browser")
         open_file(bom_file)
+
+    return True
 
 
 def run_with_dialog(parser, config, logger):

--- a/InteractiveHtmlBom/generate_interactive_bom.py
+++ b/InteractiveHtmlBom/generate_interactive_bom.py
@@ -54,4 +54,5 @@ if __name__ == "__main__":
         ibom.run_with_dialog(parser, config, logger)
     else:
         config.set_from_args(args)
-        ibom.main(parser, config, logger)
+        if not ibom.main(parser, config, logger):
+            exit(1)


### PR DESCRIPTION
When the command line script fails to parse the PCB we must indicate it
using an error level != 0.
A simple test PCB to reproduce it is:

```
(kicad_pcb (version 20171130) (host pcbnew 5.1.5+dfsg1-2~bpo10+1))
```