### PR TITLE
Added --version command line option

### DIFF
--- a/InteractiveHtmlBom/core/config.py
+++ b/InteractiveHtmlBom/core/config.py
@@ -304,11 +304,12 @@ class Config:
         dlg.finish_init()
 
     @classmethod
-    def add_options(cls, parser):
+    def add_options(cls, parser, version):
         # type: (argparse.ArgumentParser) -> None
         parser.add_argument('--show-dialog', action='store_true',
                             help='Shows config dialog. All other flags '
                                  'will be ignored.')
+        parser.add_argument('--version', action='version', version=version)
         # Html
         parser.add_argument('--dark-mode', help='Default to dark mode.',
                             action='store_true')

--- a/InteractiveHtmlBom/generate_interactive_bom.py
+++ b/InteractiveHtmlBom/generate_interactive_bom.py
@@ -41,7 +41,7 @@ if __name__ == "__main__":
                         type=lambda s: to_utf(s),
                         help="KiCad PCB file")
 
-    Config.add_options(parser)
+    Config.add_options(parser, version)
     args = parser.parse_args()
     logger = ibom.Logger(cli=True)
 


### PR DESCRIPTION
This is needed to allow external tools to detect if we have the right version installed.

I'm passing `version` as an argument, instead of just importing it from `version.py` because the code does the same a few lines after it (in the Config instance creation).